### PR TITLE
FLUID-6465: Relocate Nexus repositories to fluid-project

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 "use strict";

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ Nexus Client
 ============
 
 This repository contains code to aid in the creation of clients for the
-[GPII Nexus](https://github.com/GPII/nexus).
+[Infusion Nexus](https://github.com/fluid-project/infusion-nexus).
 
-For examples of usage, please see: https://github.com/simonbates/nexus-demos
+For examples of usage, please see: https://github.com/fluid-project/infusion-nexus-demos
 
-`gpii.nexusWebSocketBoundComponent` Infusion grade
+`fluid.nexusWebSocketBoundComponent` Infusion grade
 --------------------------------------------------
 
-The `gpii.nexusWebSocketBoundComponent` grade provides functionality for
+The `fluid.nexusWebSocketBoundComponent` grade provides functionality for
 making an Infusion component that has a binding to a Nexus peer:
 
 - Construction and destruction of Nexus peer
@@ -18,18 +18,14 @@ making an Infusion component that has a binding to a Nexus peer:
 Utility functions
 -----------------
 
-### gpii.writeNexusDefaults(host, port, gradeName, gradeDefaults)
+### fluid.writeNexusDefaults(host, port, gradeName, gradeDefaults)
 
 Writes grade defaults on a remote Nexus.
 
-### gpii.constructNexusPeer(host, port, componentPath, componentOptions)
+### fluid.constructNexusPeer(host, port, componentPath, componentOptions)
 
 Constructs a component on a remote Nexus.
 
-### gpii.destroyNexusPeer(host, port, componentPath)
+### fluid.destroyNexusPeer(host, port, componentPath)
 
 Destroys a component on a remote Nexus.
-
-### gpii.addNexusRecipe(host, port, recipeName, recipeContents)
-
-Adds a Co-Occurrence Engine recipe to a remote Nexus.

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 require("./src/NexusClientUtils.js");

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "gpii-nexus-client",
+    "name": "infusion-nexus-client",
     "version": "0.1.0",
     "license": "BSD-3-Clause",
-    "author": "GPII",
+    "author": "fluid-project",
     "repository": {
         "type": "git",
-        "url": "https://github.com/simonbates/nexus-client.git"
+        "url": "https://github.com/fluid-project/infusion-nexus-client.git"
     },
     "dependencies": {
         "infusion": "3.0.0-dev.20170727T201856Z.8c48d077a",
@@ -15,7 +15,7 @@
         "grunt": "0.4.5",
         "grunt-contrib-jshint": "1.0.0",
         "grunt-jsonlint": "1.0.7",
-        "nexus": "GPII/nexus",
+        "infusion-nexus": "fluid-project/infusion-nexus#0.2.0",
         "node-jqunit": "1.1.4"
     },
     "private": true

--- a/src/NexusClientUtils.js
+++ b/src/NexusClientUtils.js
@@ -5,18 +5,17 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 "use strict";
 
 var fluid = require("infusion");
-var gpii = fluid.registerNamespace("gpii");
 var http = require("http");
 
-fluid.registerNamespace("gpii.nexusClientUtils");
+fluid.registerNamespace("fluid.nexusClientUtils");
 
-gpii.nexusClientUtils.sendRequestWithJsonBody = function (host, port, options, body) {
+fluid.nexusClientUtils.sendRequestWithJsonBody = function (host, port, options, body) {
     options = fluid.extend({
         host: host,
         port: port,
@@ -34,7 +33,7 @@ gpii.nexusClientUtils.sendRequestWithJsonBody = function (host, port, options, b
     });
 
     req.on("error", function (error) {
-        promise.reject(gpii.nexusClientUtils.buildErrorObject(options, error));
+        promise.reject(fluid.nexusClientUtils.buildErrorObject(options, error));
     });
 
     req.write(JSON.stringify(body));
@@ -43,7 +42,7 @@ gpii.nexusClientUtils.sendRequestWithJsonBody = function (host, port, options, b
     return promise;
 };
 
-gpii.nexusClientUtils.buildErrorObject = function (requestOptions, error) {
+fluid.nexusClientUtils.buildErrorObject = function (requestOptions, error) {
     return {
         isError: true,
         message: fluid.stringTemplate("Error: %code %method %host:%port%path", {
@@ -56,21 +55,21 @@ gpii.nexusClientUtils.buildErrorObject = function (requestOptions, error) {
     };
 };
 
-gpii.writeNexusDefaults = function (host, port, gradeName, gradeDefaults) {
-    return gpii.nexusClientUtils.sendRequestWithJsonBody(host, port, {
+fluid.writeNexusDefaults = function (host, port, gradeName, gradeDefaults) {
+    return fluid.nexusClientUtils.sendRequestWithJsonBody(host, port, {
         method: "PUT",
         path: "/defaults/" + gradeName
     }, gradeDefaults);
 };
 
-gpii.constructNexusPeer = function (host, port, componentPath, componentOptions) {
-    return gpii.nexusClientUtils.sendRequestWithJsonBody(host, port, {
+fluid.constructNexusPeer = function (host, port, componentPath, componentOptions) {
+    return fluid.nexusClientUtils.sendRequestWithJsonBody(host, port, {
         method: "POST",
         path: "/components/" + componentPath
     }, componentOptions);
 };
 
-gpii.destroyNexusPeer = function (host, port, componentPath) {
+fluid.destroyNexusPeer = function (host, port, componentPath) {
     var options = {
         host: host,
         port: port,
@@ -87,7 +86,7 @@ gpii.destroyNexusPeer = function (host, port, componentPath) {
     });
 
     req.on("error", function (error) {
-        promise.reject(gpii.nexusClientUtils.buildErrorObject(options, error));
+        promise.reject(fluid.nexusClientUtils.buildErrorObject(options, error));
     });
 
     req.end();

--- a/src/NexusWebSocketBoundComponent.js
+++ b/src/NexusWebSocketBoundComponent.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 "use strict";
@@ -16,9 +16,7 @@ var WebSocket = WebSocket || fluid.require("ws");
 // TODO: Support peer management in browser
 
 (function () {
-    var gpii = fluid.registerNamespace("gpii");
-
-    fluid.defaults("gpii.nexusWebSocketBoundComponent", {
+    fluid.defaults("fluid.nexusWebSocketBoundComponent", {
         gradeNames: "fluid.modelComponent",
         members: {
             nexusHost: "localhost",
@@ -33,7 +31,7 @@ var WebSocket = WebSocket || fluid.require("ws");
         },
         invokers: {
             nexusMessageListener: {
-                funcName: "gpii.nexusWebSocketBoundComponent.messageListener",
+                funcName: "fluid.nexusWebSocketBoundComponent.messageListener",
                 args: [
                     "{that}",
                     "{that}.nexusBoundModelPath",
@@ -41,14 +39,14 @@ var WebSocket = WebSocket || fluid.require("ws");
                 ]
             },
             sendModelChangeToNexus: {
-                funcName: "gpii.nexusWebSocketBoundComponent.sendModelChangeToNexus",
+                funcName: "fluid.nexusWebSocketBoundComponent.sendModelChangeToNexus",
                 args: [
                     "{that}.websocket",
                     "{arguments}.0" // value
                 ]
             },
             destroyNexusPeerComponent: {
-                funcName: "gpii.nexusWebSocketBoundComponent.destroyPeer",
+                funcName: "fluid.nexusWebSocketBoundComponent.destroyPeer",
                 args: [ "{that}", "{that}.events.onPeerDestroyed" ]
             }
         },
@@ -60,7 +58,7 @@ var WebSocket = WebSocket || fluid.require("ws");
         },
         listeners: {
             "onCreate.constructPeer": {
-                funcName: "gpii.nexusWebSocketBoundComponent.constructPeer",
+                funcName: "fluid.nexusWebSocketBoundComponent.constructPeer",
                 args: [
                     "{that}",
                     "{that}.events.onPeerConstructed",
@@ -68,7 +66,7 @@ var WebSocket = WebSocket || fluid.require("ws");
                 ]
             },
             "onPeerConstructed.bindNexusModel": {
-                funcName: "gpii.nexusWebSocketBoundComponent.bindModel",
+                funcName: "fluid.nexusWebSocketBoundComponent.bindModel",
                 args: [
                     "{that}",
                     "{that}.receivesChangesFromNexus",
@@ -77,7 +75,7 @@ var WebSocket = WebSocket || fluid.require("ws");
                 ]
             },
             "onWebsocketConnected.registerModelListenerForNexus": {
-                funcName: "gpii.nexusWebSocketBoundComponent.registerModelListener",
+                funcName: "fluid.nexusWebSocketBoundComponent.registerModelListener",
                 args: [
                     "{that}.sendsChangesToNexus",
                     "{that}.applier",
@@ -88,9 +86,9 @@ var WebSocket = WebSocket || fluid.require("ws");
         }
     });
 
-    gpii.nexusWebSocketBoundComponent.constructPeer = function (that, onPeerConstructedEvent, onErrorConstructingPeerEvent) {
+    fluid.nexusWebSocketBoundComponent.constructPeer = function (that, onPeerConstructedEvent, onErrorConstructingPeerEvent) {
         if (that.managesPeer) {
-            gpii.constructNexusPeer(
+            fluid.constructNexusPeer(
                 that.nexusHost,
                 that.nexusPort,
                 that.nexusPeerComponentPath,
@@ -106,8 +104,8 @@ var WebSocket = WebSocket || fluid.require("ws");
         }
     };
 
-    gpii.nexusWebSocketBoundComponent.destroyPeer = function (that, onPeerDestroyedEvent) {
-        gpii.destroyNexusPeer(
+    fluid.nexusWebSocketBoundComponent.destroyPeer = function (that, onPeerDestroyedEvent) {
+        fluid.destroyNexusPeer(
             that.nexusHost,
             that.nexusPort,
             that.nexusPeerComponentPath
@@ -116,7 +114,7 @@ var WebSocket = WebSocket || fluid.require("ws");
         });
     };
 
-    gpii.nexusWebSocketBoundComponent.bindModel = function (that, shouldRegisterMessageListener, messageListener, onWebsocketConnectedEvent) {
+    fluid.nexusWebSocketBoundComponent.bindModel = function (that, shouldRegisterMessageListener, messageListener, onWebsocketConnectedEvent) {
         var bindModelUrl = fluid.stringTemplate("ws://%host:%port/bindModel/%componentPath/%modelPath", {
             host: that.nexusHost,
             port: that.nexusPort,
@@ -132,26 +130,26 @@ var WebSocket = WebSocket || fluid.require("ws");
         };
     };
 
-    gpii.nexusWebSocketBoundComponent.registerModelListener = function (shouldRegisterModelChangeListener, applier, modelPath, modelChangeListener) {
+    fluid.nexusWebSocketBoundComponent.registerModelListener = function (shouldRegisterModelChangeListener, applier, modelPath, modelChangeListener) {
         if (shouldRegisterModelChangeListener) {
             // TODO: Segs here?
             applier.modelChanged.addListener(modelPath, modelChangeListener);
         }
     };
 
-    gpii.nexusWebSocketBoundComponent.messageListener = function (that, modelPath, evt) {
+    fluid.nexusWebSocketBoundComponent.messageListener = function (that, modelPath, evt) {
         var value = JSON.parse(evt.data);
-        gpii.nexusWebSocketBoundComponent.updateModel(that, modelPath, value);
+        fluid.nexusWebSocketBoundComponent.updateModel(that, modelPath, value);
     };
 
-    gpii.nexusWebSocketBoundComponent.sendModelChangeToNexus =  function (websocket, value) {
+    fluid.nexusWebSocketBoundComponent.sendModelChangeToNexus =  function (websocket, value) {
         websocket.send(JSON.stringify({
             path: "",
             value: value
         }));
     };
 
-    gpii.nexusWebSocketBoundComponent.updateModel = function (component, modelPath, value) {
+    fluid.nexusWebSocketBoundComponent.updateModel = function (component, modelPath, value) {
         var oldValue = fluid.get(component.model, modelPath);
         var changes = fluid.modelPairToChanges(value, oldValue, modelPath);
         fluid.fireChanges(component.applier, changes);

--- a/tests/NexusClientUtilsTests.js
+++ b/tests/NexusClientUtilsTests.js
@@ -5,54 +5,53 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 "use strict";
 
 var fluid = require("infusion"),
-    kettle = require("kettle"),
-    gpii = fluid.registerNamespace("gpii");
+    kettle = require("kettle");
 
 require("../index.js");
 // TODO: Is using NexusTestUtils.js reasonable?
-fluid.require("%gpii-nexus/src/test/NexusTestUtils.js");
+fluid.require("%infusion-nexus/src/test/NexusTestUtils.js");
 
 kettle.loadTestingSupport();
 
-fluid.registerNamespace("gpii.tests.nexusClientUtils.writeNexusDefaults");
-fluid.registerNamespace("gpii.tests.nexusClientUtils.constructAndDestroy");
+fluid.registerNamespace("fluid.tests.nexusClientUtils.writeNexusDefaults");
+fluid.registerNamespace("fluid.tests.nexusClientUtils.constructAndDestroy");
 
-gpii.tests.nexusClientUtils.newGradeOptions = {
+fluid.tests.nexusClientUtils.newGradeOptions = {
     gradeNames: ["fluid.component"],
     name1: "hello NexusClientUtils"
 };
 
-gpii.tests.nexusClientUtils.componentOptions = {
+fluid.tests.nexusClientUtils.componentOptions = {
     type: "fluid.modelComponent",
     model: {
         name1: "hello NexusClientUtils"
     }
 };
 
-gpii.tests.nexusClientUtils.writeNexusDefaults.testDefs = [
+fluid.tests.nexusClientUtils.writeNexusDefaults.testDefs = [
     {
         name: "NexusClientUtils writeNexusDefaults tests",
         gradeNames: "gpii.test.nexus.testCaseHolder",
         expect: 4,
         config: {
             configName: "gpii.tests.nexus.config",
-            configPath: "%gpii-nexus/tests/configs"
+            configPath: "%infusion-nexus/tests/configs"
         },
-        testGradeName: "gpii.tests.nexusClientUtils.newGrade",
+        testGradeName: "fluid.tests.nexusClientUtils.newGrade",
         sequence: [
             {
-                task: "gpii.writeNexusDefaults",
+                task: "fluid.writeNexusDefaults",
                 args: [
                     "localhost",
                     "{configuration}.options.serverPort",
                     "{tests}.options.testGradeName",
-                    gpii.tests.nexusClientUtils.newGradeOptions
+                    fluid.tests.nexusClientUtils.newGradeOptions
                 ],
                 resolve: "jqUnit.assert",
                 resolveArgs: ["Write defaults promise resolved"]
@@ -67,7 +66,7 @@ gpii.tests.nexusClientUtils.writeNexusDefaults.testDefs = [
                     "{arguments}.0",
                     "{readDefaultsRequest}",
                     {
-                        gradeNames: ["fluid.component", "gpii.tests.nexusClientUtils.newGrade"],
+                        gradeNames: ["fluid.component", "fluid.tests.nexusClientUtils.newGrade"],
                         name1: "hello NexusClientUtils"
                     }
                 ]
@@ -76,14 +75,14 @@ gpii.tests.nexusClientUtils.writeNexusDefaults.testDefs = [
     }
 ];
 
-gpii.tests.nexusClientUtils.constructAndDestroy.testDefs = [
+fluid.tests.nexusClientUtils.constructAndDestroy.testDefs = [
     {
         name: "NexusClientUtils construct and destroy tests",
         gradeNames: "gpii.test.nexus.testCaseHolder",
         expect: 6,
         config: {
             configName: "gpii.tests.nexus.config",
-            configPath: "%gpii-nexus/tests/configs"
+            configPath: "%infusion-nexus/tests/configs"
         },
         testComponentPath: "nexusClientUtilsConstructAndDestroyTestsComponentOne",
         sequence: [
@@ -98,12 +97,12 @@ gpii.tests.nexusClientUtils.constructAndDestroy.testDefs = [
             },
             // Construct and check that the constructed component model is as expected
             {
-                task: "gpii.constructNexusPeer",
+                task: "fluid.constructNexusPeer",
                 args: [
                     "localhost",
                     "{configuration}.options.serverPort",
                     "{tests}.options.testComponentPath",
-                    gpii.tests.nexusClientUtils.componentOptions
+                    fluid.tests.nexusClientUtils.componentOptions
                 ],
                 resolve: "jqUnit.assert",
                 resolveArgs: ["Component construct promise resolved"]
@@ -114,12 +113,12 @@ gpii.tests.nexusClientUtils.constructAndDestroy.testDefs = [
                     "Model is as expected",
                     "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
-                    gpii.tests.nexusClientUtils.componentOptions.model
+                    fluid.tests.nexusClientUtils.componentOptions.model
                 ]
             },
             // Destroy
             {
-                task: "gpii.destroyNexusPeer",
+                task: "fluid.destroyNexusPeer",
                 args: [
                     "localhost",
                     "{configuration}.options.serverPort",
@@ -142,18 +141,18 @@ gpii.tests.nexusClientUtils.constructAndDestroy.testDefs = [
 
 // Test error cases with no Nexus running
 
-fluid.defaults("gpii.tests.nexusClientUtils.noNexusTestTree", {
+fluid.defaults("fluid.tests.nexusClientUtils.noNexusTestTree", {
     gradeNames: ["fluid.test.testEnvironment"],
     serverHost: "localhost",
     serverPort: 8082,
     components: {
         noNexusTester: {
-            type: "gpii.tests.nexusClientUtils.noNexusTester"
+            type: "fluid.tests.nexusClientUtils.noNexusTester"
         }
     }
 });
 
-fluid.defaults("gpii.tests.nexusClientUtils.noNexusTester", {
+fluid.defaults("fluid.tests.nexusClientUtils.noNexusTester", {
     gradeNames: ["fluid.test.testCaseHolder"],
     modules: [{
         name: "NexusClientUtils No Nexus tests",
@@ -163,12 +162,12 @@ fluid.defaults("gpii.tests.nexusClientUtils.noNexusTester", {
                 expect: 1,
                 sequence: [
                     {
-                        task: "gpii.writeNexusDefaults",
+                        task: "fluid.writeNexusDefaults",
                         args: [
                             "{testEnvironment}.options.serverHost",
                             "{testEnvironment}.options.serverPort",
                             "someGradeName",
-                            gpii.tests.nexusClientUtils.newGradeOptions
+                            fluid.tests.nexusClientUtils.newGradeOptions
                         ],
                         reject: "jqUnit.assert",
                         rejectArgs: ["Write defaults promise rejected"]
@@ -180,12 +179,12 @@ fluid.defaults("gpii.tests.nexusClientUtils.noNexusTester", {
                 expect: 1,
                 sequence: [
                     {
-                        task: "gpii.constructNexusPeer",
+                        task: "fluid.constructNexusPeer",
                         args: [
                             "{testEnvironment}.options.serverHost",
                             "{testEnvironment}.options.serverPort",
                             "someComponentPath",
-                            gpii.tests.nexusClientUtils.componentOptions
+                            fluid.tests.nexusClientUtils.componentOptions
                         ],
                         reject: "jqUnit.assert",
                         rejectArgs: ["Construct component promise rejected"]
@@ -197,7 +196,7 @@ fluid.defaults("gpii.tests.nexusClientUtils.noNexusTester", {
                 expect: 1,
                 sequence: [
                     {
-                        task: "gpii.destroyNexusPeer",
+                        task: "fluid.destroyNexusPeer",
                         args: [
                             "{testEnvironment}.options.serverHost",
                             "{testEnvironment}.options.serverPort",
@@ -212,6 +211,6 @@ fluid.defaults("gpii.tests.nexusClientUtils.noNexusTester", {
     }]
 });
 
-kettle.test.bootstrapServer(gpii.tests.nexusClientUtils.writeNexusDefaults.testDefs);
-kettle.test.bootstrapServer(gpii.tests.nexusClientUtils.constructAndDestroy.testDefs);
-fluid.test.runTests(["gpii.tests.nexusClientUtils.noNexusTestTree"]);
+kettle.test.bootstrapServer(fluid.tests.nexusClientUtils.writeNexusDefaults.testDefs);
+kettle.test.bootstrapServer(fluid.tests.nexusClientUtils.constructAndDestroy.testDefs);
+fluid.test.runTests(["fluid.tests.nexusClientUtils.noNexusTestTree"]);

--- a/tests/WebSocketBoundComponentTests.js
+++ b/tests/WebSocketBoundComponentTests.js
@@ -5,29 +5,28 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 "use strict";
 
 var fluid = require("infusion"),
-    kettle = require("kettle"),
-    gpii = fluid.registerNamespace("gpii");
+    kettle = require("kettle");
 
 require("../index.js");
 // TODO: Is using NexusTestUtils.js reasonable?
-fluid.require("%gpii-nexus/src/test/NexusTestUtils.js");
+fluid.require("%infusion-nexus/src/test/NexusTestUtils.js");
 
 kettle.loadTestingSupport();
 
-fluid.registerNamespace("gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates");
-fluid.registerNamespace("gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates");
-fluid.registerNamespace("gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates");
-fluid.registerNamespace("gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates");
+fluid.registerNamespace("fluid.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates");
+fluid.registerNamespace("fluid.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates");
+fluid.registerNamespace("fluid.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates");
+fluid.registerNamespace("fluid.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates");
 
 // Base testCaseHolder
 
-fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder", {
+fluid.defaults("fluid.tests.nexusClient.webSocketBoundComponent.testCaseHolder", {
     gradeNames: ["gpii.test.nexus.testCaseHolder"],
     testComponentPath: "nexusWebSocketBoundComponentPeer",
     clientManagesPeer: false,
@@ -38,7 +37,7 @@ fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder", 
     },
     components: {
         client: {
-            type: "gpii.nexusWebSocketBoundComponent",
+            type: "fluid.nexusWebSocketBoundComponent",
             createOnEvent: "{tests}.events.createClient",
             options: {
                 members: {
@@ -66,14 +65,14 @@ fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder", 
 
 // Tests
 
-gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates.testDefs = [
+fluid.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates.testDefs = [
     {
         name: "nexusWebSocketBoundComponent manage peer and send updates tests",
-        gradeNames: "gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
+        gradeNames: "fluid.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
         expect: 6,
         config: {
             configName: "gpii.tests.nexus.config",
-            configPath: "%gpii-nexus/tests/configs"
+            configPath: "%infusion-nexus/tests/configs"
         },
         clientManagesPeer: true,
         clientSendsChangesToNexus: true,
@@ -91,7 +90,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates.testDefs
                 func: "{tests}.events.createClient.fire"
             },
             {
-                event: "{that gpii.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
+                event: "{that fluid.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
                 listener: "jqUnit.assert",
                 args: ["WebSocket connected"]
             },
@@ -133,14 +132,14 @@ gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates.testDefs
     }
 ];
 
-gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates.testDefs = [
+fluid.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates.testDefs = [
     {
         name: "nexusWebSocketBoundComponent manage peer and receive updates tests",
-        gradeNames: "gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
+        gradeNames: "fluid.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
         expect: 5,
         config: {
             configName: "gpii.tests.nexus.config",
-            configPath: "%gpii-nexus/tests/configs"
+            configPath: "%infusion-nexus/tests/configs"
         },
         clientManagesPeer: true,
         clientSendsChangesToNexus: false,
@@ -158,7 +157,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates.testD
                 func: "{tests}.events.createClient.fire"
             },
             {
-                event: "{that gpii.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
+                event: "{that fluid.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
                 listener: "jqUnit.assert",
                 args: ["WebSocket connected"]
             },
@@ -199,14 +198,14 @@ gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates.testD
     }
 ];
 
-gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDefs = [
+fluid.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDefs = [
     {
         name: "nexusWebSocketBoundComponent do not manage peer and send updates tests",
-        gradeNames: "gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
+        gradeNames: "fluid.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
         expect: 6,
         config: {
             configName: "gpii.tests.nexus.config",
-            configPath: "%gpii-nexus/tests/configs"
+            configPath: "%infusion-nexus/tests/configs"
         },
         clientManagesPeer: false,
         clientSendsChangesToNexus: true,
@@ -214,7 +213,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDe
         sequence: [
             // Construct peer
             {
-                task: "gpii.constructNexusPeer",
+                task: "fluid.constructNexusPeer",
                 args: [
                     "localhost",
                     "{configuration}.options.serverPort",
@@ -234,7 +233,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDe
                 func: "{tests}.events.createClient.fire"
             },
             {
-                event: "{that gpii.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
+                event: "{that fluid.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
                 listener: "jqUnit.assert",
                 args: ["WebSocket connected"]
             },
@@ -274,14 +273,14 @@ gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDe
     }
 ];
 
-gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.testDefs = [
+fluid.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.testDefs = [
     {
         name: "nexusWebSocketBoundComponent do not manage peer and receive updates tests",
-        gradeNames: "gpii.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
+        gradeNames: "fluid.tests.nexusClient.webSocketBoundComponent.testCaseHolder",
         expect: 6,
         config: {
             configName: "gpii.tests.nexus.config",
-            configPath: "%gpii-nexus/tests/configs"
+            configPath: "%infusion-nexus/tests/configs"
         },
         clientManagesPeer: false,
         clientSendsChangesToNexus: false,
@@ -289,7 +288,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.tes
         sequence: [
             // Construct peer
             {
-                task: "gpii.constructNexusPeer",
+                task: "fluid.constructNexusPeer",
                 args: [
                     "localhost",
                     "{configuration}.options.serverPort",
@@ -309,7 +308,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.tes
                 func: "{tests}.events.createClient.fire"
             },
             {
-                event: "{that gpii.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
+                event: "{that fluid.nexusWebSocketBoundComponent}.events.onWebsocketConnected",
                 listener: "jqUnit.assert",
                 args: ["WebSocket connected"]
             },
@@ -365,7 +364,7 @@ gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.tes
 
 // Test error cases with no Nexus running
 
-fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.noNexusTestTree", {
+fluid.defaults("fluid.tests.nexusClient.webSocketBoundComponent.noNexusTestTree", {
     gradeNames: ["fluid.test.testEnvironment"],
     serverHost: "localhost",
     serverPort: 8082,
@@ -374,7 +373,7 @@ fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.noNexusTestTree",
     },
     components: {
         client: {
-            type: "gpii.nexusWebSocketBoundComponent",
+            type: "fluid.nexusWebSocketBoundComponent",
             createOnEvent: "{testEnvironment}.events.createClient",
             options: {
                 members: {
@@ -389,12 +388,12 @@ fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.noNexusTestTree",
             }
         },
         noNexusTester: {
-            type: "gpii.tests.nexusClient.webSocketBoundComponent.noNexusTester"
+            type: "fluid.tests.nexusClient.webSocketBoundComponent.noNexusTester"
         }
     }
 });
 
-fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.noNexusTester", {
+fluid.defaults("fluid.tests.nexusClient.webSocketBoundComponent.noNexusTester", {
     gradeNames: ["fluid.test.testCaseHolder"],
     modules: [{
         name: "nexusWebSocketBoundComponent No Nexus tests",
@@ -407,7 +406,7 @@ fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.noNexusTester", {
                         func: "{testEnvironment}.events.createClient.fire"
                     },
                     {
-                        event: "{testEnvironment gpii.nexusWebSocketBoundComponent}.events.onErrorConstructingPeer",
+                        event: "{testEnvironment fluid.nexusWebSocketBoundComponent}.events.onErrorConstructingPeer",
                         listener: "jqUnit.assert",
                         args: ["Error constructing peer"]
                     }
@@ -417,8 +416,8 @@ fluid.defaults("gpii.tests.nexusClient.webSocketBoundComponent.noNexusTester", {
     }]
 });
 
-kettle.test.bootstrapServer(gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates.testDefs);
-kettle.test.bootstrapServer(gpii.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates.testDefs);
-kettle.test.bootstrapServer(gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDefs);
-kettle.test.bootstrapServer(gpii.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.testDefs);
-fluid.test.runTests(["gpii.tests.nexusClient.webSocketBoundComponent.noNexusTestTree"]);
+kettle.test.bootstrapServer(fluid.tests.nexusClient.webSocketBoundComponent.managePeerAndSendUpdates.testDefs);
+kettle.test.bootstrapServer(fluid.tests.nexusClient.webSocketBoundComponent.managePeerAndReceiveUpdates.testDefs);
+kettle.test.bootstrapServer(fluid.tests.nexusClient.webSocketBoundComponent.noManagePeerAndSendUpdates.testDefs);
+kettle.test.bootstrapServer(fluid.tests.nexusClient.webSocketBoundComponent.noManagePeerAndReceiveUpdates.testDefs);
+fluid.test.runTests(["fluid.tests.nexusClient.webSocketBoundComponent.noNexusTestTree"]);

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -5,7 +5,7 @@ Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
 
 You may obtain a copy of the License at
-https://raw.githubusercontent.com/simonbates/nexus-client/master/LICENSE.txt
+https://raw.githubusercontent.com/fluid-project/infusion-nexus-client/master/LICENSE.txt
 */
 
 "use strict";


### PR DESCRIPTION
Please note that this pull request does not update the version of the Nexus that the `infusion-nexus-client` depends on. Therefore, the code still contains some references to `gpi.nexus`: the functions and grades that the `infusion-nexus-client` uses from Nexus.

I'd like to tackle updating to the latest Nexus as another piece of work.